### PR TITLE
fix(release): mark v0.3.0 as alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## 0.3.0 - 2026-07-24
+## 0.3.0-alpha - 2026-07-24
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6696,7 +6696,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winderust"
-version = "0.3.0"
+version = "0.3.0-alpha"
 dependencies = [
  "atomic-write-file",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winderust"
-version = "0.3.0"
+version = "0.3.0-alpha"
 edition = "2021"
 authors = ["Tatsh Siow"]
 description = "Windows Performance & Power Manager"


### PR DESCRIPTION
## What changed

- Correct the release version from `0.3.0` to `0.3.0-alpha`.
- Align Cargo metadata, lockfile, and changelog.

## Why

Winderust remains a public alpha release, and the package, tag, executable, and release notes must use the same version.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --locked --all-targets -- -D warnings -D unsafe-op-in-unsafe-fn`
- `cargo test --locked` (328 passed)
- `scripts\build_release.cmd`
- Embedded file and product versions verified as `0.3.0-alpha`
