### PR TITLE
feat(adaptive-engine): add observation-only bottleneck classification

### DIFF
--- a/.agents/memory/30-reference-library.md
+++ b/.agents/memory/30-reference-library.md
@@ -629,3 +629,14 @@ Windows exposes no documented process-wide suspension query. The Process List
 therefore reports suspension only for process IDs currently suspended and
 tracked by Winderust; it does not infer suspension from undocumented NT thread
 state.
+
+# GPU Engine utilization
+
+- Implementation: `src/platform/windows/gpu_usage.rs` owns the English PDH wildcard query for
+  `\\GPU Engine(*)\\Utilization Percentage`, formatted-array parsing, per-engine aggregation, and
+  query cleanup. `src/bottleneck_classifier.rs` consumes only the resulting observation.
+- References: [PdhAddEnglishCounterW](https://learn.microsoft.com/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw),
+  [PdhGetFormattedCounterArrayW](https://learn.microsoft.com/windows/win32/api/pdh/nf-pdh-pdhgetformattedcounterarrayw).
+- Contract: GPU Engine instances are process-scoped. Strip only the `pid_<number>_` prefix, sum
+  matching physical-engine instances, clamp each engine to 100%, and report the busiest engine.
+  Missing or invalid samples are unavailable observations, not zero utilization.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target/
 /target-next/
 /target-bench/
+/target-bottleneck/
 /benchmark-results/
 /dist/
 

--- a/benchmark/bottleneck_classifier_probe.ps1
+++ b/benchmark/bottleneck_classifier_probe.ps1
@@ -1,0 +1,76 @@
+param(
+    [ValidateRange(5, 300)]
+    [int]$Seconds = 15,
+    [ValidateRange(1, 10)]
+    [int]$SampleIntervalSeconds = 1,
+    [string]$OutputPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$sampleCount = [Math]::Max(2, [Math]::Ceiling($Seconds / $SampleIntervalSeconds))
+$processorCount = [Environment]::ProcessorCount
+$probe = [Diagnostics.Process]::GetCurrentProcess()
+$probeCpuBefore = $probe.TotalProcessorTime.TotalMilliseconds
+$startedAt = [DateTimeOffset]::UtcNow
+
+$samples = Get-Counter -Counter @(
+    '\Processor Information(_Total)\% Processor Utility',
+    '\Processor Information(*)\% Processor Utility',
+    '\GPU Engine(*)\Utilization Percentage'
+) -SampleInterval $SampleIntervalSeconds -MaxSamples $sampleCount
+
+$rows = foreach ($sample in $samples) {
+    $cpu = @($sample.CounterSamples | Where-Object Path -Like '*processor information*')
+    $cpuTotal = @($cpu | Where-Object InstanceName -EQ '_total' | Select-Object -First 1).CookedValue
+    $cpuCores = @($cpu | Where-Object InstanceName -NE '_total' | ForEach-Object CookedValue)
+
+    $engineTotals = @{}
+    foreach ($counter in $sample.CounterSamples | Where-Object Path -Like '*gpu engine*') {
+        $engine = $counter.InstanceName -replace '^pid_\d+_', ''
+        $engineTotals[$engine] = [double]($engineTotals[$engine] + $counter.CookedValue)
+    }
+    $gpu = @($engineTotals.Values | ForEach-Object { [Math]::Min(100.0, $_) } | Sort-Object -Descending | Select-Object -First 1)
+
+    $total = if ($cpuTotal.Count) { [double]$cpuTotal[0] } else { 0.0 }
+    $core = if ($cpuCores.Count) { [double]($cpuCores | Measure-Object -Maximum).Maximum } else { 0.0 }
+    $gpuBusy = if ($gpu.Count) { [double]$gpu[0] } else { 0.0 }
+    $cpuBusy = $total -ge 85.0 -or $core -ge 90.0
+    $gpuBusyEnough = $gpuBusy -ge 75.0
+    $state = if ($total -ge 85.0 -and $gpuBusyEnough) {
+        'Mixed'
+    } elseif ($gpuBusyEnough) {
+        'GPU Bound'
+    } elseif ($cpuBusy) {
+        'CPU Bound'
+    } else {
+        'Headroom'
+    }
+
+    [pscustomobject]@{
+        timestamp = $sample.Timestamp.ToUniversalTime().ToString('O')
+        cpu_total_percent = [Math]::Round($total, 2)
+        cpu_busiest_processor_percent = [Math]::Round($core, 2)
+        gpu_busiest_engine_percent = [Math]::Round($gpuBusy, 2)
+        state = $state
+    }
+}
+
+$probe.Refresh()
+$elapsed = ([DateTimeOffset]::UtcNow - $startedAt).TotalMilliseconds
+$probeCpuMs = [Math]::Max(0.0, $probe.TotalProcessorTime.TotalMilliseconds - $probeCpuBefore)
+$stateGroups = @($rows | Group-Object state | Sort-Object Count -Descending)
+$report = [pscustomobject]@{
+    recorded_at = [DateTimeOffset]::UtcNow.ToString('O')
+    duration_seconds = [Math]::Round($elapsed / 1000.0, 2)
+    sample_interval_seconds = $SampleIntervalSeconds
+    samples = $rows.Count
+    dominant_state = if ($stateGroups.Count) { $stateGroups[0].Name } else { 'Unknown' }
+    dominant_state_percent = if ($rows.Count) { [Math]::Round(($stateGroups[0].Count / $rows.Count) * 100.0, 1) } else { 0.0 }
+    probe_cpu_percent = if ($elapsed -gt 0) { [Math]::Round(($probeCpuMs / ($elapsed * $processorCount)) * 100.0, 4) } else { 0.0 }
+    observations = @($rows)
+}
+
+if ($OutputPath) {
+    $report | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+}
+$report

--- a/benchmark/results/bottleneck-cpu-v2-screening-20260822.json
+++ b/benchmark/results/bottleneck-cpu-v2-screening-20260822.json
@@ -1,0 +1,116 @@
+﻿{
+    "recorded_at":  "2026-08-22T12:38:28.7350869+00:00",
+    "duration_seconds":  17.14,
+    "sample_interval_seconds":  1,
+    "samples":  15,
+    "dominant_state":  "CPU Bound",
+    "dominant_state_percent":  100,
+    "probe_cpu_percent":  0.45,
+    "observations":  [
+                         {
+                             "timestamp":  "2026-08-22T12:38:13.4598546Z",
+                             "cpu_total_percent":  100.15,
+                             "cpu_busiest_processor_percent":  100.16,
+                             "gpu_busiest_engine_percent":  36.41,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:14.4914947Z",
+                             "cpu_total_percent":  99.73,
+                             "cpu_busiest_processor_percent":  99.73,
+                             "gpu_busiest_engine_percent":  39.22,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:15.5233236Z",
+                             "cpu_total_percent":  100.09,
+                             "cpu_busiest_processor_percent":  100.09,
+                             "gpu_busiest_engine_percent":  50.25,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:16.5389609Z",
+                             "cpu_total_percent":  100.02,
+                             "cpu_busiest_processor_percent":  100.02,
+                             "gpu_busiest_engine_percent":  45.71,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:17.5657991Z",
+                             "cpu_total_percent":  99.89,
+                             "cpu_busiest_processor_percent":  99.89,
+                             "gpu_busiest_engine_percent":  52.45,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:18.5884354Z",
+                             "cpu_total_percent":  99.9,
+                             "cpu_busiest_processor_percent":  99.9,
+                             "gpu_busiest_engine_percent":  59.01,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:19.6145388Z",
+                             "cpu_total_percent":  99.81,
+                             "cpu_busiest_processor_percent":  99.81,
+                             "gpu_busiest_engine_percent":  59.96,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:20.6498191Z",
+                             "cpu_total_percent":  100.06,
+                             "cpu_busiest_processor_percent":  100.08,
+                             "gpu_busiest_engine_percent":  55.98,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:21.6700547Z",
+                             "cpu_total_percent":  100.02,
+                             "cpu_busiest_processor_percent":  100.01,
+                             "gpu_busiest_engine_percent":  44.92,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:22.6931352Z",
+                             "cpu_total_percent":  99.81,
+                             "cpu_busiest_processor_percent":  99.83,
+                             "gpu_busiest_engine_percent":  42.69,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:23.7184296Z",
+                             "cpu_total_percent":  100.01,
+                             "cpu_busiest_processor_percent":  100.01,
+                             "gpu_busiest_engine_percent":  52.18,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:24.7431519Z",
+                             "cpu_total_percent":  99.82,
+                             "cpu_busiest_processor_percent":  99.83,
+                             "gpu_busiest_engine_percent":  43.39,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:25.7557799Z",
+                             "cpu_total_percent":  99.89,
+                             "cpu_busiest_processor_percent":  99.88,
+                             "gpu_busiest_engine_percent":  50.74,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:26.7694392Z",
+                             "cpu_total_percent":  100.36,
+                             "cpu_busiest_processor_percent":  100.36,
+                             "gpu_busiest_engine_percent":  61.06,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:38:27.7991169Z",
+                             "cpu_total_percent":  99.83,
+                             "cpu_busiest_processor_percent":  99.83,
+                             "gpu_busiest_engine_percent":  48.29,
+                             "state":  "CPU Bound"
+                         }
+                     ]
+}

--- a/benchmark/results/bottleneck-game-gpu-adjusted-v2-screening-20260822.json
+++ b/benchmark/results/bottleneck-game-gpu-adjusted-v2-screening-20260822.json
@@ -1,0 +1,221 @@
+﻿{
+    "recorded_at":  "2026-08-22T12:37:41.7273273+00:00",
+    "duration_seconds":  31.1,
+    "sample_interval_seconds":  1,
+    "samples":  30,
+    "dominant_state":  "GPU Bound",
+    "dominant_state_percent":  100,
+    "probe_cpu_percent":  0.179,
+    "observations":  [
+                         {
+                             "timestamp":  "2026-08-22T12:37:12.0082559Z",
+                             "cpu_total_percent":  25.5,
+                             "cpu_busiest_processor_percent":  69.84,
+                             "gpu_busiest_engine_percent":  80.16,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:13.0149728Z",
+                             "cpu_total_percent":  26.45,
+                             "cpu_busiest_processor_percent":  74.83,
+                             "gpu_busiest_engine_percent":  79.57,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:14.0211376Z",
+                             "cpu_total_percent":  22.22,
+                             "cpu_busiest_processor_percent":  82.38,
+                             "gpu_busiest_engine_percent":  83.54,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:15.0269166Z",
+                             "cpu_total_percent":  23.33,
+                             "cpu_busiest_processor_percent":  75.41,
+                             "gpu_busiest_engine_percent":  83.29,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:16.0430433Z",
+                             "cpu_total_percent":  28.01,
+                             "cpu_busiest_processor_percent":  75.99,
+                             "gpu_busiest_engine_percent":  80.23,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:17.0573819Z",
+                             "cpu_total_percent":  25.98,
+                             "cpu_busiest_processor_percent":  81.9,
+                             "gpu_busiest_engine_percent":  80.95,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:18.0759954Z",
+                             "cpu_total_percent":  26.35,
+                             "cpu_busiest_processor_percent":  80.7,
+                             "gpu_busiest_engine_percent":  79.91,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:19.0788713Z",
+                             "cpu_total_percent":  23.88,
+                             "cpu_busiest_processor_percent":  73.9,
+                             "gpu_busiest_engine_percent":  81.59,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:20.0840507Z",
+                             "cpu_total_percent":  27.05,
+                             "cpu_busiest_processor_percent":  75.89,
+                             "gpu_busiest_engine_percent":  81.28,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:21.0999660Z",
+                             "cpu_total_percent":  25.86,
+                             "cpu_busiest_processor_percent":  83.41,
+                             "gpu_busiest_engine_percent":  83.7,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:22.1027871Z",
+                             "cpu_total_percent":  28.86,
+                             "cpu_busiest_processor_percent":  82.8,
+                             "gpu_busiest_engine_percent":  83.66,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:23.1197761Z",
+                             "cpu_total_percent":  26.62,
+                             "cpu_busiest_processor_percent":  88.31,
+                             "gpu_busiest_engine_percent":  79.77,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:24.1377672Z",
+                             "cpu_total_percent":  28.35,
+                             "cpu_busiest_processor_percent":  95.08,
+                             "gpu_busiest_engine_percent":  79.4,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:25.1407328Z",
+                             "cpu_total_percent":  30.32,
+                             "cpu_busiest_processor_percent":  87.28,
+                             "gpu_busiest_engine_percent":  78.29,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:26.1459821Z",
+                             "cpu_total_percent":  27.42,
+                             "cpu_busiest_processor_percent":  76.58,
+                             "gpu_busiest_engine_percent":  80.68,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:27.1620426Z",
+                             "cpu_total_percent":  29.41,
+                             "cpu_busiest_processor_percent":  79.73,
+                             "gpu_busiest_engine_percent":  76.85,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:28.1751034Z",
+                             "cpu_total_percent":  28.48,
+                             "cpu_busiest_processor_percent":  72.95,
+                             "gpu_busiest_engine_percent":  77.58,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:29.1895153Z",
+                             "cpu_total_percent":  26.13,
+                             "cpu_busiest_processor_percent":  80.24,
+                             "gpu_busiest_engine_percent":  78.58,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:30.2044622Z",
+                             "cpu_total_percent":  27.97,
+                             "cpu_busiest_processor_percent":  90.57,
+                             "gpu_busiest_engine_percent":  78.24,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:31.2087367Z",
+                             "cpu_total_percent":  28.38,
+                             "cpu_busiest_processor_percent":  87.79,
+                             "gpu_busiest_engine_percent":  78.76,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:32.2112681Z",
+                             "cpu_total_percent":  26.3,
+                             "cpu_busiest_processor_percent":  91.32,
+                             "gpu_busiest_engine_percent":  78.91,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:33.2151492Z",
+                             "cpu_total_percent":  23.66,
+                             "cpu_busiest_processor_percent":  81.65,
+                             "gpu_busiest_engine_percent":  81.54,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:34.2189312Z",
+                             "cpu_total_percent":  26,
+                             "cpu_busiest_processor_percent":  79.19,
+                             "gpu_busiest_engine_percent":  78.33,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:35.2346462Z",
+                             "cpu_total_percent":  25.4,
+                             "cpu_busiest_processor_percent":  88.08,
+                             "gpu_busiest_engine_percent":  79.44,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:36.2417794Z",
+                             "cpu_total_percent":  25.77,
+                             "cpu_busiest_processor_percent":  84.08,
+                             "gpu_busiest_engine_percent":  80.44,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:37.2464681Z",
+                             "cpu_total_percent":  25.37,
+                             "cpu_busiest_processor_percent":  80.88,
+                             "gpu_busiest_engine_percent":  80.81,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:38.2493566Z",
+                             "cpu_total_percent":  27.09,
+                             "cpu_busiest_processor_percent":  77.19,
+                             "gpu_busiest_engine_percent":  82.22,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:39.2624856Z",
+                             "cpu_total_percent":  25.89,
+                             "cpu_busiest_processor_percent":  71.38,
+                             "gpu_busiest_engine_percent":  81.33,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:40.2792797Z",
+                             "cpu_total_percent":  24.78,
+                             "cpu_busiest_processor_percent":  78.22,
+                             "gpu_busiest_engine_percent":  80.97,
+                             "state":  "GPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:37:41.2965283Z",
+                             "cpu_total_percent":  25.55,
+                             "cpu_busiest_processor_percent":  86.28,
+                             "gpu_busiest_engine_percent":  79.74,
+                             "state":  "GPU Bound"
+                         }
+                     ]
+}

--- a/benchmark/results/bottleneck-game-gpu-screening-20260822.json
+++ b/benchmark/results/bottleneck-game-gpu-screening-20260822.json
@@ -1,0 +1,221 @@
+﻿{
+    "recorded_at":  "2026-08-22T12:03:48.6653172+00:00",
+    "duration_seconds":  31.68,
+    "sample_interval_seconds":  1,
+    "samples":  30,
+    "dominant_state":  "CPU Bound",
+    "dominant_state_percent":  76.7,
+    "probe_cpu_percent":  0.2343,
+    "observations":  [
+                         {
+                             "timestamp":  "2026-08-22T12:03:18.6303054Z",
+                             "cpu_total_percent":  48.33,
+                             "cpu_busiest_processor_percent":  112.89,
+                             "gpu_busiest_engine_percent":  25.61,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:19.6436922Z",
+                             "cpu_total_percent":  43.25,
+                             "cpu_busiest_processor_percent":  98.7,
+                             "gpu_busiest_engine_percent":  29.59,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:20.6552743Z",
+                             "cpu_total_percent":  41.36,
+                             "cpu_busiest_processor_percent":  96.69,
+                             "gpu_busiest_engine_percent":  28.65,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:21.6725718Z",
+                             "cpu_total_percent":  42.04,
+                             "cpu_busiest_processor_percent":  101.36,
+                             "gpu_busiest_engine_percent":  29.72,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:22.6824508Z",
+                             "cpu_total_percent":  40.48,
+                             "cpu_busiest_processor_percent":  92.01,
+                             "gpu_busiest_engine_percent":  28.3,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:23.6913102Z",
+                             "cpu_total_percent":  42.55,
+                             "cpu_busiest_processor_percent":  95.01,
+                             "gpu_busiest_engine_percent":  28.77,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:24.7037708Z",
+                             "cpu_total_percent":  41.87,
+                             "cpu_busiest_processor_percent":  92.57,
+                             "gpu_busiest_engine_percent":  28.83,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:25.7178636Z",
+                             "cpu_total_percent":  41.08,
+                             "cpu_busiest_processor_percent":  98.93,
+                             "gpu_busiest_engine_percent":  28.37,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:26.7334938Z",
+                             "cpu_total_percent":  39.14,
+                             "cpu_busiest_processor_percent":  108.18,
+                             "gpu_busiest_engine_percent":  29.13,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:27.7449425Z",
+                             "cpu_total_percent":  39.23,
+                             "cpu_busiest_processor_percent":  113.01,
+                             "gpu_busiest_engine_percent":  28.87,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:28.7585259Z",
+                             "cpu_total_percent":  39.72,
+                             "cpu_busiest_processor_percent":  96.47,
+                             "gpu_busiest_engine_percent":  29.31,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:29.7749917Z",
+                             "cpu_total_percent":  39.61,
+                             "cpu_busiest_processor_percent":  103.61,
+                             "gpu_busiest_engine_percent":  31.43,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:30.7889468Z",
+                             "cpu_total_percent":  40.9,
+                             "cpu_busiest_processor_percent":  108.9,
+                             "gpu_busiest_engine_percent":  30.2,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:31.8062372Z",
+                             "cpu_total_percent":  40.86,
+                             "cpu_busiest_processor_percent":  103.93,
+                             "gpu_busiest_engine_percent":  29.06,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:32.8201220Z",
+                             "cpu_total_percent":  37.54,
+                             "cpu_busiest_processor_percent":  106.97,
+                             "gpu_busiest_engine_percent":  35.76,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:33.8329867Z",
+                             "cpu_total_percent":  39.41,
+                             "cpu_busiest_processor_percent":  99.77,
+                             "gpu_busiest_engine_percent":  29.08,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:34.8484529Z",
+                             "cpu_total_percent":  41.14,
+                             "cpu_busiest_processor_percent":  99.9,
+                             "gpu_busiest_engine_percent":  27.76,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:35.8620073Z",
+                             "cpu_total_percent":  42.27,
+                             "cpu_busiest_processor_percent":  86.81,
+                             "gpu_busiest_engine_percent":  35.65,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:36.8760117Z",
+                             "cpu_total_percent":  42.71,
+                             "cpu_busiest_processor_percent":  96.65,
+                             "gpu_busiest_engine_percent":  33.69,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:37.8879490Z",
+                             "cpu_total_percent":  41.33,
+                             "cpu_busiest_processor_percent":  89.98,
+                             "gpu_busiest_engine_percent":  35.76,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:38.9007763Z",
+                             "cpu_total_percent":  38.87,
+                             "cpu_busiest_processor_percent":  91.37,
+                             "gpu_busiest_engine_percent":  39.09,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:39.9178056Z",
+                             "cpu_total_percent":  38.03,
+                             "cpu_busiest_processor_percent":  95.63,
+                             "gpu_busiest_engine_percent":  36.51,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:40.9347483Z",
+                             "cpu_total_percent":  39.96,
+                             "cpu_busiest_processor_percent":  92.71,
+                             "gpu_busiest_engine_percent":  27.81,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:41.9453435Z",
+                             "cpu_total_percent":  41.5,
+                             "cpu_busiest_processor_percent":  85.73,
+                             "gpu_busiest_engine_percent":  28.36,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:42.9498161Z",
+                             "cpu_total_percent":  41.48,
+                             "cpu_busiest_processor_percent":  89.82,
+                             "gpu_busiest_engine_percent":  28.67,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:43.9616201Z",
+                             "cpu_total_percent":  44.47,
+                             "cpu_busiest_processor_percent":  76.43,
+                             "gpu_busiest_engine_percent":  26.09,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:44.9742059Z",
+                             "cpu_total_percent":  40.91,
+                             "cpu_busiest_processor_percent":  77.82,
+                             "gpu_busiest_engine_percent":  26.21,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:45.9852472Z",
+                             "cpu_total_percent":  41.3,
+                             "cpu_busiest_processor_percent":  75.31,
+                             "gpu_busiest_engine_percent":  26.91,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:46.9951988Z",
+                             "cpu_total_percent":  42.61,
+                             "cpu_busiest_processor_percent":  96.18,
+                             "gpu_busiest_engine_percent":  21.89,
+                             "state":  "CPU Bound"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T12:03:48.0027687Z",
+                             "cpu_total_percent":  42.37,
+                             "cpu_busiest_processor_percent":  96.41,
+                             "gpu_busiest_engine_percent":  19.83,
+                             "state":  "CPU Bound"
+                         }
+                     ]
+}

--- a/benchmark/results/bottleneck-idle-overhead-5s-20260822.json
+++ b/benchmark/results/bottleneck-idle-overhead-5s-20260822.json
@@ -1,0 +1,53 @@
+﻿{
+    "recorded_at":  "2026-08-22T09:35:07.8623733+00:00",
+    "duration_seconds":  30.47,
+    "sample_interval_seconds":  5,
+    "samples":  6,
+    "dominant_state":  "Headroom",
+    "dominant_state_percent":  100,
+    "probe_cpu_percent":  0.0929,
+    "observations":  [
+                         {
+                             "timestamp":  "2026-08-22T09:34:42.6717402Z",
+                             "cpu_total_percent":  1.74,
+                             "cpu_busiest_processor_percent":  6.5,
+                             "gpu_busiest_engine_percent":  0.02,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:34:47.6753331Z",
+                             "cpu_total_percent":  1.67,
+                             "cpu_busiest_processor_percent":  6.15,
+                             "gpu_busiest_engine_percent":  0,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:34:52.6912840Z",
+                             "cpu_total_percent":  1.39,
+                             "cpu_busiest_processor_percent":  5.43,
+                             "gpu_busiest_engine_percent":  0,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:34:57.7049289Z",
+                             "cpu_total_percent":  1.56,
+                             "cpu_busiest_processor_percent":  6.25,
+                             "gpu_busiest_engine_percent":  0,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:35:02.7202317Z",
+                             "cpu_total_percent":  1.58,
+                             "cpu_busiest_processor_percent":  6.2,
+                             "gpu_busiest_engine_percent":  0,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:35:07.7232124Z",
+                             "cpu_total_percent":  2.58,
+                             "cpu_busiest_processor_percent":  8.21,
+                             "gpu_busiest_engine_percent":  0,
+                             "state":  "Headroom"
+                         }
+                     ]
+}

--- a/benchmark/results/bottleneck-idle-screening-20260822.json
+++ b/benchmark/results/bottleneck-idle-screening-20260822.json
@@ -1,0 +1,116 @@
+﻿{
+    "recorded_at":  "2026-08-22T09:27:47.4778077+00:00",
+    "duration_seconds":  15.69,
+    "sample_interval_seconds":  1,
+    "samples":  15,
+    "dominant_state":  "Headroom",
+    "dominant_state_percent":  100,
+    "probe_cpu_percent":  0.2054,
+    "observations":  [
+                         {
+                             "timestamp":  "2026-08-22T09:27:33.0943492Z",
+                             "cpu_total_percent":  2.58,
+                             "cpu_busiest_processor_percent":  12.26,
+                             "gpu_busiest_engine_percent":  0.22,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:34.1000377Z",
+                             "cpu_total_percent":  1.81,
+                             "cpu_busiest_processor_percent":  9.5,
+                             "gpu_busiest_engine_percent":  0.23,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:35.1176609Z",
+                             "cpu_total_percent":  1.42,
+                             "cpu_busiest_processor_percent":  4.13,
+                             "gpu_busiest_engine_percent":  0.14,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:36.1331792Z",
+                             "cpu_total_percent":  1.64,
+                             "cpu_busiest_processor_percent":  8.52,
+                             "gpu_busiest_engine_percent":  0.22,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:37.1339441Z",
+                             "cpu_total_percent":  2.09,
+                             "cpu_busiest_processor_percent":  12.7,
+                             "gpu_busiest_engine_percent":  0.21,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:38.1452918Z",
+                             "cpu_total_percent":  1.56,
+                             "cpu_busiest_processor_percent":  7.15,
+                             "gpu_busiest_engine_percent":  0.22,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:39.1596412Z",
+                             "cpu_total_percent":  2.22,
+                             "cpu_busiest_processor_percent":  6.25,
+                             "gpu_busiest_engine_percent":  0.22,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:40.1722934Z",
+                             "cpu_total_percent":  1.73,
+                             "cpu_busiest_processor_percent":  6.8,
+                             "gpu_busiest_engine_percent":  0.21,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:41.1751622Z",
+                             "cpu_total_percent":  2.11,
+                             "cpu_busiest_processor_percent":  12.56,
+                             "gpu_busiest_engine_percent":  0.22,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:42.2044456Z",
+                             "cpu_total_percent":  1.97,
+                             "cpu_busiest_processor_percent":  8,
+                             "gpu_busiest_engine_percent":  0.21,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:43.2057357Z",
+                             "cpu_total_percent":  1.7,
+                             "cpu_busiest_processor_percent":  6.23,
+                             "gpu_busiest_engine_percent":  0.29,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:44.2166662Z",
+                             "cpu_total_percent":  1.87,
+                             "cpu_busiest_processor_percent":  6.87,
+                             "gpu_busiest_engine_percent":  0.14,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:45.2347272Z",
+                             "cpu_total_percent":  1.6,
+                             "cpu_busiest_processor_percent":  6.13,
+                             "gpu_busiest_engine_percent":  0.14,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:46.2504457Z",
+                             "cpu_total_percent":  2.35,
+                             "cpu_busiest_processor_percent":  13.16,
+                             "gpu_busiest_engine_percent":  0.22,
+                             "state":  "Headroom"
+                         },
+                         {
+                             "timestamp":  "2026-08-22T09:27:47.2523546Z",
+                             "cpu_total_percent":  1.64,
+                             "cpu_busiest_processor_percent":  6.43,
+                             "gpu_busiest_engine_percent":  0.22,
+                             "state":  "Headroom"
+                         }
+                     ]
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -610,6 +610,15 @@ background_efficiency:
   no_custom_rules: "No custom rules are configured."
 
 adaptive_engine:
+  bottleneck_classifier: "System Bottleneck"
+  bottleneck_unknown: "Collecting data"
+  bottleneck_headroom: "Headroom"
+  bottleneck_cpu_bound: "CPU Bound"
+  bottleneck_gpu_bound: "GPU Bound"
+  bottleneck_mixed: "Mixed CPU/GPU"
+  total_cpu: "Total CPU"
+  busiest_cpu: "Busiest CPU"
+  busiest_gpu: "Busiest GPU engine"
   intro_1: "Adaptive Engine combines dynamic processor power control with workload-aware CPU scheduling."
   intro_2: "Power Save and Balanced scale with demand. Performance and Speed hold fixed processor targets."
   intro_3: "Balanced is recommended for everyday use; choose a fixed profile only for sustained performance."

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -612,6 +612,15 @@ background_efficiency:
   no_custom_rules: "尚未設定自訂規則。"
 
 adaptive_engine:
+  bottleneck_classifier: "系統瓶頸"
+  bottleneck_unknown: "正在收集資料"
+  bottleneck_headroom: "仍有餘裕"
+  bottleneck_cpu_bound: "CPU 受限"
+  bottleneck_gpu_bound: "GPU 受限"
+  bottleneck_mixed: "CPU/GPU 混合受限"
+  total_cpu: "CPU 總使用率"
+  busiest_cpu: "最忙碌 CPU"
+  busiest_gpu: "最忙碌 GPU 引擎"
   intro_1: "自適應引擎會整合動態處理器電源控制與工作負載感知 CPU 排程。"
   intro_2: "省電和平衡會依需求動態調整；效能和速度會維持固定的處理器目標。"
   intro_3: "日常使用建議選擇平衡；只有需要持續高效能時才使用固定模式。"

--- a/src/backend/automation.rs
+++ b/src/backend/automation.rs
@@ -20,6 +20,7 @@ use crate::{
     app_suspension::{AppSuspensionManager, AppSuspensionSnapshot},
     application::settings::{AutoExclusionPatch, RuntimeSettingsSnapshot, SettingsRevision},
     background_efficiency::{BackgroundEfficiencyManager, BackgroundEfficiencySnapshot},
+    bottleneck_classifier::{BottleneckClassifier, BottleneckSnapshot},
     config::{
         AccentColorSource, AnimationMode, AppThemeMode, CpuAllocationSettings, PowerPlanSettings,
         ProcessGpuPriority, ProcessIoPriority, ProcessMemoryPriority, ProcessPrioritySetting,
@@ -103,6 +104,7 @@ const CPU_ALLOCATION_RECONCILIATION_RETRY_MAX: Duration = Duration::from_secs(60
 const CPU_LIMITER_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const PERFORMANCE_MODE_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const ADAPTIVE_POWER_PLAN_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+const BOTTLENECK_CLASSIFIER_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
 const ADAPTIVE_IO_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const PROCESS_PRIORITY_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const THREAD_PRIORITY_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
@@ -289,6 +291,7 @@ impl ProcessControlCommand {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RuntimeFeatureStatus {
+    pub bottleneck_classifier: BottleneckSnapshot,
     pub background_efficiency: BackgroundEfficiencySnapshot,
     pub app_suspension: AppSuspensionSnapshot,
     pub cpu_sets_soft: CpuAllocationSnapshot,
@@ -1109,6 +1112,8 @@ fn run_background_automation(shared: Arc<SharedAutomationState>) -> Result<(), S
             || feature_refresh_required(&settings, by_running_app_required(&settings));
         let cpu_scheduler_refresh_required = settings_changed
             || feature_refresh_required(&settings, cpu_scheduler_required(&settings));
+        let bottleneck_classifier_refresh_required = settings_changed
+            || feature_refresh_required(&settings, bottleneck_classifier_required(&settings));
         let adaptive_power_plan_refresh_required = settings_changed
             || feature_refresh_required(&settings, adaptive_power_plan_required(&settings))
             || runner.adaptive_power_plan_active();
@@ -1191,6 +1196,17 @@ fn run_background_automation(shared: Arc<SharedAutomationState>) -> Result<(), S
                 RefreshDomain::CpuScheduler,
                 now,
                 cpu_scheduler_refresh_interval,
+            );
+        }
+        if bottleneck_classifier_refresh_required
+            && scheduler.is_due(RefreshDomain::BottleneckClassifier, now)
+        {
+            let status = runner.run_bottleneck_classifier_update(&settings);
+            update_bottleneck_classifier_status(&shared, status);
+            scheduler.schedule_after(
+                RefreshDomain::BottleneckClassifier,
+                now,
+                BOTTLENECK_CLASSIFIER_REFRESH_INTERVAL,
             );
         }
         if adaptive_power_plan_refresh_required
@@ -1470,6 +1486,11 @@ fn run_background_automation(shared: Arc<SharedAutomationState>) -> Result<(), S
                     cpu_scheduler_refresh_required,
                     RefreshDomain::CpuScheduler,
                     cpu_scheduler_refresh_interval,
+                ),
+                (
+                    bottleneck_classifier_refresh_required,
+                    RefreshDomain::BottleneckClassifier,
+                    BOTTLENECK_CLASSIFIER_REFRESH_INTERVAL,
                 ),
                 (
                     adaptive_power_plan_refresh_required,

--- a/src/backend/automation/requirements.rs
+++ b/src/backend/automation/requirements.rs
@@ -319,9 +319,14 @@ pub(super) fn automation_worker_required(settings: &Settings) -> bool {
     settings.general.enabled
         && (power_plan_checks_required(settings)
             || adaptive_power_plan_required(settings)
+            || bottleneck_classifier_required(settings)
             || app_suspension_required(settings)
             || process_appearance_scan_required(settings)
             || timer_resolution_required(settings))
+}
+
+pub(super) fn bottleneck_classifier_required(settings: &Settings) -> bool {
+    settings.general.enabled && settings.adaptive_engine.enabled
 }
 
 pub(super) fn windows_event_watcher_required(settings: &Settings) -> bool {

--- a/src/backend/automation/runner.rs
+++ b/src/backend/automation/runner.rs
@@ -55,6 +55,7 @@ pub(super) struct RuntimeCore {
     cpu_usage: CpuUsageSnapshot,
     next_cpu_usage_refresh: Option<Instant>,
     cpu_monitor: CpuUsageMonitor,
+    bottleneck_classifier: BottleneckClassifier,
     per_processor_cpu_monitor: PerProcessorUsageMonitor,
     io_monitor: IoUsageMonitor,
     adaptive_processor_topology: Vec<LogicalProcessorInfo>,
@@ -558,6 +559,17 @@ impl RuntimeCore {
         self.cpu_pressure_restraint_active = snapshot.cpu_pressure_restraint_active;
         self.cpu_scheduler_foreground_cpu_usage_tenths = snapshot.foreground_cpu_usage_tenths;
         snapshot
+    }
+
+    pub(super) fn run_bottleneck_classifier_update(
+        &mut self,
+        settings: &Settings,
+    ) -> BottleneckSnapshot {
+        if !bottleneck_classifier_required(settings) {
+            return self.bottleneck_classifier.reset();
+        }
+        self.refresh_cpu_usage();
+        self.bottleneck_classifier.sample(self.cpu_usage.percent)
     }
 
     pub(super) fn run_adaptive_power_plan_update(

--- a/src/backend/automation/status.rs
+++ b/src/backend/automation/status.rs
@@ -207,6 +207,18 @@ pub(super) fn update_cpu_scheduler_status(
     );
 }
 
+pub(super) fn update_bottleneck_classifier_status(
+    shared: &SharedAutomationState,
+    status: BottleneckSnapshot,
+) {
+    update_feature_status(
+        shared,
+        status,
+        |feature_status| &feature_status.bottleneck_classifier,
+        |feature_status| &mut feature_status.bottleneck_classifier,
+    );
+}
+
 pub(super) fn update_io_priority_status(
     shared: &SharedAutomationState,
     status: IoPrioritySnapshot,

--- a/src/backend/automation/tests.rs
+++ b/src/backend/automation/tests.rs
@@ -1005,6 +1005,18 @@ fn automation_worker_runs_for_adaptive_power_plan_alone() {
 }
 
 #[test]
+fn automation_worker_runs_for_bottleneck_classifier_alone() {
+    let mut settings = Settings::default();
+    settings.by_activity.enabled = false;
+    settings.by_foreground.enabled = false;
+    settings.adaptive_engine.enabled = true;
+    settings.adaptive_engine.processor_power_policy_enabled = false;
+
+    assert!(bottleneck_classifier_required(&settings));
+    assert!(automation_worker_required(&settings));
+}
+
+#[test]
 fn adaptive_engine_uses_low_power_refresh_cadence() {
     assert_eq!(
         automation_refresh_interval(false, true, Duration::from_secs(1)),

--- a/src/backend/crash_recovery.rs
+++ b/src/backend/crash_recovery.rs
@@ -2241,6 +2241,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unknown_lints, clippy::manual_isolate_lowest_one)]
     fn affinity_recovery_restores_a_disposable_process() -> Result<(), String> {
         let child = DisposableChild::spawn()?;
         let process = child.process_handle()?;

--- a/src/bottleneck_classifier.rs
+++ b/src/bottleneck_classifier.rs
@@ -1,0 +1,157 @@
+use crate::{cpu::PerProcessorUsageMonitor, platform::windows::gpu_usage::GpuUsageQuery};
+
+const CPU_BUSY_PERCENT: f32 = 85.0;
+const BUSIEST_CPU_BUSY_PERCENT: f32 = 90.0;
+const GPU_BUSY_PERCENT: f32 = 75.0;
+const STABLE_SAMPLE_COUNT: u8 = 3;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BottleneckState {
+    #[default]
+    Unknown,
+    Headroom,
+    CpuBound,
+    GpuBound,
+    Mixed,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BottleneckSnapshot {
+    pub enabled: bool,
+    pub state: BottleneckState,
+    pub total_cpu_tenths: Option<u16>,
+    pub busiest_cpu_tenths: Option<u16>,
+    pub busiest_gpu_tenths: Option<u16>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct BottleneckClassifier {
+    processors: PerProcessorUsageMonitor,
+    gpu: Option<GpuUsageQuery>,
+    candidate: BottleneckState,
+    candidate_samples: u8,
+    stable: BottleneckState,
+}
+
+impl BottleneckClassifier {
+    pub(crate) fn reset(&mut self) -> BottleneckSnapshot {
+        self.gpu = None;
+        self.candidate = BottleneckState::Unknown;
+        self.candidate_samples = 0;
+        self.stable = BottleneckState::Unknown;
+        BottleneckSnapshot::default()
+    }
+
+    pub(crate) fn sample(&mut self, total_cpu: Option<f32>) -> BottleneckSnapshot {
+        let busiest_cpu = self
+            .processors
+            .sample()
+            .and_then(|usage| usage.into_iter().reduce(f32::max));
+        let gpu = self.gpu_sample();
+        let (busiest_gpu, last_error) = match gpu {
+            Ok(value) => (value, None),
+            Err(error) => (None, Some(error)),
+        };
+        let raw = total_cpu
+            .map(|total_cpu| classify(total_cpu, busiest_cpu, busiest_gpu))
+            .unwrap_or(BottleneckState::Unknown);
+        self.stabilize(raw);
+
+        BottleneckSnapshot {
+            enabled: true,
+            state: self.stable,
+            total_cpu_tenths: total_cpu.and_then(tenths),
+            busiest_cpu_tenths: busiest_cpu.and_then(tenths),
+            busiest_gpu_tenths: busiest_gpu.and_then(tenths),
+            last_error,
+        }
+    }
+
+    fn stabilize(&mut self, raw: BottleneckState) {
+        if raw == self.candidate {
+            self.candidate_samples = self.candidate_samples.saturating_add(1);
+        } else {
+            self.candidate = raw;
+            self.candidate_samples = 1;
+        }
+        if self.candidate_samples >= STABLE_SAMPLE_COUNT {
+            self.stable = raw;
+        }
+    }
+
+    fn gpu_sample(&mut self) -> Result<Option<f32>, String> {
+        if self.gpu.is_none() {
+            self.gpu = Some(GpuUsageQuery::open().map_err(|error| error.to_string())?);
+        }
+        let Some(gpu) = self.gpu.as_ref() else {
+            return Err("GPU query was not initialized.".to_owned());
+        };
+        let result = gpu.sample().map_err(|error| error.to_string());
+        if result.is_err() {
+            self.gpu = None;
+        }
+        result
+    }
+}
+
+fn tenths(value: f32) -> Option<u16> {
+    value
+        .is_finite()
+        .then(|| (value.clamp(0.0, 100.0) * 10.0).round() as u16)
+}
+
+fn classify(total_cpu: f32, busiest_cpu: Option<f32>, gpu: Option<f32>) -> BottleneckState {
+    let Some(gpu) = gpu else {
+        return BottleneckState::Unknown;
+    };
+    if total_cpu >= CPU_BUSY_PERCENT && gpu >= GPU_BUSY_PERCENT {
+        BottleneckState::Mixed
+    } else if gpu >= GPU_BUSY_PERCENT {
+        BottleneckState::GpuBound
+    } else if total_cpu >= CPU_BUSY_PERCENT
+        || busiest_cpu.is_some_and(|usage| usage >= BUSIEST_CPU_BUSY_PERCENT)
+    {
+        BottleneckState::CpuBound
+    } else {
+        BottleneckState::Headroom
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classification_covers_validated_boundaries() {
+        assert_eq!(
+            classify(20.0, Some(30.0), Some(10.0)),
+            BottleneckState::Headroom
+        );
+        assert_eq!(
+            classify(86.0, Some(90.0), Some(40.0)),
+            BottleneckState::CpuBound
+        );
+        assert_eq!(
+            classify(30.0, Some(40.0), Some(80.0)),
+            BottleneckState::GpuBound
+        );
+        assert_eq!(
+            classify(90.0, Some(95.0), Some(80.0)),
+            BottleneckState::Mixed
+        );
+        assert_eq!(classify(90.0, Some(95.0), None), BottleneckState::Unknown);
+    }
+
+    #[test]
+    fn state_changes_only_after_three_matching_samples() {
+        let mut classifier = BottleneckClassifier::default();
+        classifier.stabilize(BottleneckState::GpuBound);
+        classifier.stabilize(BottleneckState::GpuBound);
+        assert_eq!(classifier.stable, BottleneckState::Unknown);
+        classifier.stabilize(BottleneckState::GpuBound);
+        assert_eq!(classifier.stable, BottleneckState::GpuBound);
+        classifier.stabilize(BottleneckState::CpuBound);
+        assert_eq!(classifier.stable, BottleneckState::GpuBound);
+    }
+}

--- a/src/control/cpu_allocation.rs
+++ b/src/control/cpu_allocation.rs
@@ -2968,6 +2968,7 @@ mod tests {
 
     #[test]
     #[ignore = "modifies and restores a disposable Windows process; run in explicit integration QA"]
+    #[allow(unknown_lints, clippy::manual_isolate_lowest_one)]
     fn cpu_allocation_live_apply_and_clean_release() -> Result<(), String> {
         struct DisposableProcess(Child);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod action_log;
 mod activity;
 mod application;
 mod backend;
+mod bottleneck_classifier;
 mod config;
 mod control;
 mod cpu;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -5,6 +5,7 @@ use crate::win_util::last_error;
 pub(crate) mod cpu_allocation;
 pub(crate) mod dynamic_priority_boost;
 pub(crate) mod gpu_priority;
+pub(crate) mod gpu_usage;
 pub(crate) mod io_priority;
 pub(crate) mod memory_priority;
 pub(crate) mod memory_trim;

--- a/src/platform/windows/gpu_usage.rs
+++ b/src/platform/windows/gpu_usage.rs
@@ -1,0 +1,195 @@
+use std::{collections::HashMap, fmt, mem::size_of, ptr};
+
+use windows_sys::Win32::System::Performance::{
+    PdhAddEnglishCounterW, PdhCloseQuery, PdhCollectQueryData, PdhGetFormattedCounterArrayW,
+    PdhOpenQueryW, PDH_CSTATUS_INVALID_DATA, PDH_CSTATUS_NEW_DATA, PDH_CSTATUS_VALID_DATA,
+    PDH_FMT_COUNTERVALUE_ITEM_W, PDH_FMT_DOUBLE, PDH_HCOUNTER, PDH_HQUERY, PDH_MORE_DATA,
+};
+
+const GPU_ENGINE_COUNTER: &[u16] = &[
+    92, 71, 80, 85, 32, 69, 110, 103, 105, 110, 101, 40, 42, 41, 92, 85, 116, 105, 108, 105, 122,
+    97, 116, 105, 111, 110, 32, 80, 101, 114, 99, 101, 110, 116, 97, 103, 101, 0,
+];
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GpuUsageError(u32);
+
+impl fmt::Display for GpuUsageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "PDH GPU Engine query failed with status 0x{:08X}.",
+            self.0
+        )
+    }
+}
+
+pub(crate) struct GpuUsageQuery {
+    query: PDH_HQUERY,
+    counter: PDH_HCOUNTER,
+}
+
+impl GpuUsageQuery {
+    pub(crate) fn open() -> Result<Self, GpuUsageError> {
+        let mut query = ptr::null_mut();
+        // SAFETY: The output pointer is valid and PDH owns the returned query handle.
+        let status = unsafe { PdhOpenQueryW(ptr::null(), 0, &mut query) };
+        if status != 0 {
+            return Err(GpuUsageError(status));
+        }
+
+        let mut counter = ptr::null_mut();
+        // SAFETY: `query` is an open PDH query and the counter path is NUL-terminated.
+        let status =
+            unsafe { PdhAddEnglishCounterW(query, GPU_ENGINE_COUNTER.as_ptr(), 0, &mut counter) };
+        if status != 0 {
+            // SAFETY: `query` was successfully opened above and is not used after closing.
+            unsafe { PdhCloseQuery(query) };
+            return Err(GpuUsageError(status));
+        }
+
+        Ok(Self { query, counter })
+    }
+
+    pub(crate) fn sample(&self) -> Result<Option<f32>, GpuUsageError> {
+        // SAFETY: `self.query` stays open for the lifetime of this object.
+        let status = unsafe { PdhCollectQueryData(self.query) };
+        if status == PDH_CSTATUS_INVALID_DATA {
+            return Ok(None);
+        }
+        if status != 0 {
+            return Err(GpuUsageError(status));
+        }
+
+        let mut byte_count = 0;
+        let mut item_count = 0;
+        // SAFETY: A null buffer asks PDH for the required byte count.
+        let status = unsafe {
+            PdhGetFormattedCounterArrayW(
+                self.counter,
+                PDH_FMT_DOUBLE,
+                &mut byte_count,
+                &mut item_count,
+                ptr::null_mut(),
+            )
+        };
+        if status == PDH_CSTATUS_INVALID_DATA {
+            return Ok(None);
+        }
+        if status != PDH_MORE_DATA {
+            return if status == 0 {
+                Ok(None)
+            } else {
+                Err(GpuUsageError(status))
+            };
+        }
+
+        let words = (byte_count as usize).div_ceil(size_of::<usize>());
+        let mut buffer = vec![0usize; words];
+        // SAFETY: The aligned buffer has the byte capacity requested by PDH.
+        let status = unsafe {
+            PdhGetFormattedCounterArrayW(
+                self.counter,
+                PDH_FMT_DOUBLE,
+                &mut byte_count,
+                &mut item_count,
+                buffer.as_mut_ptr().cast(),
+            )
+        };
+        if status == PDH_CSTATUS_INVALID_DATA {
+            return Ok(None);
+        }
+        if status != 0 {
+            return Err(GpuUsageError(status));
+        }
+
+        // SAFETY: PDH wrote `item_count` formatted items at the start of the aligned buffer.
+        let items = unsafe {
+            std::slice::from_raw_parts(
+                buffer.as_ptr().cast::<PDH_FMT_COUNTERVALUE_ITEM_W>(),
+                item_count as usize,
+            )
+        };
+        let start = buffer.as_ptr().addr();
+        let end = start.saturating_add(buffer.len() * size_of::<usize>());
+        let mut samples = Vec::with_capacity(items.len());
+        for item in items {
+            if !matches!(
+                item.FmtValue.CStatus,
+                PDH_CSTATUS_VALID_DATA | PDH_CSTATUS_NEW_DATA
+            ) {
+                continue;
+            }
+            // SAFETY: PDH_FMT_DOUBLE selects the `doubleValue` union field.
+            let value = unsafe { item.FmtValue.Anonymous.doubleValue };
+            if !value.is_finite() || value < 0.0 {
+                continue;
+            }
+            let Some(name) = bounded_wide_string(item.szName, start, end) else {
+                continue;
+            };
+            samples.push((name, value));
+        }
+        Ok(busiest_engine(&samples))
+    }
+}
+
+fn busiest_engine(samples: &[(String, f64)]) -> Option<f32> {
+    let mut engines = HashMap::<&str, f64>::new();
+    for (name, value) in samples {
+        let key = name
+            .strip_prefix("pid_")
+            .and_then(|rest| rest.find('_').map(|split| &rest[split + 1..]))
+            .unwrap_or(name);
+        *engines.entry(key).or_default() += value;
+    }
+    engines
+        .values()
+        .copied()
+        .map(|value| value.clamp(0.0, 100.0) as f32)
+        .reduce(f32::max)
+}
+
+fn bounded_wide_string(pointer: *const u16, start: usize, end: usize) -> Option<String> {
+    let address = pointer.addr();
+    if pointer.is_null() || address < start || address >= end || !address.is_multiple_of(2) {
+        return None;
+    }
+    let max_len = (end - address) / size_of::<u16>();
+    // SAFETY: The pointer was validated inside the PDH-owned output buffer and max_len stays within it.
+    let wide = unsafe { std::slice::from_raw_parts(pointer, max_len) };
+    let len = wide.iter().position(|unit| *unit == 0)?;
+    Some(String::from_utf16_lossy(&wide[..len]))
+}
+
+impl Drop for GpuUsageQuery {
+    fn drop(&mut self) {
+        // SAFETY: This object uniquely owns the open query handle.
+        unsafe { PdhCloseQuery(self.query) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gpu_process_samples_are_summed_by_physical_engine() {
+        let samples = vec![
+            ("pid_1_luid_0_phys_0_eng_0_engtype_3D".to_owned(), 40.0),
+            ("pid_2_luid_0_phys_0_eng_0_engtype_3D".to_owned(), 35.0),
+            ("pid_1_luid_0_phys_0_eng_1_engtype_Copy".to_owned(), 20.0),
+        ];
+        assert_eq!(busiest_engine(&samples), Some(75.0));
+    }
+
+    #[test]
+    #[ignore = "reads live Windows GPU Engine performance counters"]
+    fn live_gpu_engine_query_returns_a_sample() {
+        let query = GpuUsageQuery::open().unwrap_or_else(|error| panic!("{error}"));
+        let _ = query.sample().unwrap_or_else(|error| panic!("{error}"));
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let sample = query.sample().unwrap_or_else(|error| panic!("{error}"));
+        assert!(sample.is_some(), "GPU Engine returned no valid sample");
+    }
+}

--- a/src/platform/windows/power_plan.rs
+++ b/src/platform/windows/power_plan.rs
@@ -465,8 +465,10 @@ fn encode_power_string(value: &str) -> Vec<u8> {
 
 fn decode_power_string(buffer: &[u8]) -> String {
     let utf16 = buffer
-        .chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| u16::from_le_bytes(*chunk))
         .take_while(|code| *code != 0)
         .collect::<Vec<_>>();
     String::from_utf16_lossy(&utf16)

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -13,6 +13,7 @@ pub(crate) enum RefreshDomain {
     CpuAllocationReconciliation,
     ByRunningApp,
     CpuScheduler,
+    BottleneckClassifier,
     AdaptivePowerPlan,
     ProcessPriority,
     ThreadPriority,
@@ -26,7 +27,7 @@ pub(crate) enum RefreshDomain {
     ControllerActivity,
 }
 
-pub(crate) const ALL_REFRESH_DOMAINS: [RefreshDomain; 21] = [
+pub(crate) const ALL_REFRESH_DOMAINS: [RefreshDomain; 22] = [
     RefreshDomain::PowerPlanCheck,
     RefreshDomain::BackgroundEfficiency,
     RefreshDomain::AppSuspension,
@@ -37,6 +38,7 @@ pub(crate) const ALL_REFRESH_DOMAINS: [RefreshDomain; 21] = [
     RefreshDomain::CpuAllocationReconciliation,
     RefreshDomain::ByRunningApp,
     RefreshDomain::CpuScheduler,
+    RefreshDomain::BottleneckClassifier,
     RefreshDomain::AdaptivePowerPlan,
     RefreshDomain::ProcessPriority,
     RefreshDomain::ThreadPriority,

--- a/src/ui/app/pages/adaptive_engine_page.rs
+++ b/src/ui/app/pages/adaptive_engine_page.rs
@@ -212,6 +212,7 @@ impl WinderustApp {
                     self.render_normalized_feature_status(Page::AdaptiveEngine)
                         .expect("Adaptive Engine always has normalized runtime status"),
                 )
+                .child(self.render_bottleneck_classifier_status())
                 .into_any_element()
         } else {
             self.render_adaptive_engine_presets_content(cx)

--- a/src/ui/app/shared/page_components.rs
+++ b/src/ui/app/shared/page_components.rs
@@ -186,6 +186,12 @@ fn status_metric_row(label: String, value: String) -> gpui::Div {
         )
 }
 
+fn percent_tenths(value: Option<u16>) -> String {
+    value
+        .map(|value| format!("{}.{:01}%", value / 10, value % 10))
+        .unwrap_or_else(|| "—".to_owned())
+}
+
 fn status_log_row(
     label: String,
     entry: Option<&ActionLogEntry>,
@@ -628,6 +634,42 @@ impl WinderustApp {
                 ))
                 .into_any_element(),
         )
+    }
+
+    pub(in crate::ui::app) fn render_bottleneck_classifier_status(&self) -> AnyElement {
+        use crate::bottleneck_classifier::BottleneckState;
+
+        let status = &self.feature_status.bottleneck_classifier;
+        let state = match status.state {
+            BottleneckState::Unknown => t!("adaptive_engine.bottleneck_unknown"),
+            BottleneckState::Headroom => t!("adaptive_engine.bottleneck_headroom"),
+            BottleneckState::CpuBound => t!("adaptive_engine.bottleneck_cpu_bound"),
+            BottleneckState::GpuBound => t!("adaptive_engine.bottleneck_gpu_bound"),
+            BottleneckState::Mixed => t!("adaptive_engine.bottleneck_mixed"),
+        };
+        v_flex()
+            .w_full()
+            .gap_1()
+            .child(text_muted(
+                t!("adaptive_engine.bottleneck_classifier").to_string(),
+            ))
+            .child(status_metric_row(
+                t!("common.status").to_string(),
+                state.to_string(),
+            ))
+            .child(status_metric_row(
+                t!("adaptive_engine.total_cpu").to_string(),
+                percent_tenths(status.total_cpu_tenths),
+            ))
+            .child(status_metric_row(
+                t!("adaptive_engine.busiest_cpu").to_string(),
+                percent_tenths(status.busiest_cpu_tenths),
+            ))
+            .child(status_metric_row(
+                t!("adaptive_engine.busiest_gpu").to_string(),
+                percent_tenths(status.busiest_gpu_tenths),
+            ))
+            .into_any_element()
     }
 
     pub(in crate::ui::app) fn render_page_status_panel(


### PR DESCRIPTION
## Summary
- add an observation-only CPU/GPU bottleneck classifier to Adaptive Engine
- sample native Windows GPU Engine PDH counters every five seconds and stabilize results across three samples
- show Headroom, CPU Bound, GPU Bound, Mixed CPU/GPU, or Collecting data in Adaptive Engine status
- add a reproducible classifier probe and validation datasets

## Validation
- cargo fmt -- --check
- cargo clippy --locked --all-targets -- -D warnings -D unsafe-op-in-unsafe-fn
- cargo test --locked: 658 passed, 0 failed, 13 ignored
- live Windows GPU Engine integration test passed
- release build and UI smoke test passed
- hidden/tray A/B: approximately 0.039% incremental total CPU capacity on a 16-thread system; no measurable working-set increase

The classifier is inspection-only and does not change power plans, priorities, affinity, or other runtime policy.